### PR TITLE
Add built-in functions for HEAD, OPTIONS and CONNECT

### DIFF
--- a/src/grillon.rs
+++ b/src/grillon.rs
@@ -34,7 +34,7 @@ impl Grillon {
         })
     }
 
-    /// Creates a new [`Request`] initialized with a GET method and the given path.
+    /// Creates a new [`Request`] initialized with a `GET` method and the given path.
     ///
     /// # Example
     ///
@@ -50,7 +50,7 @@ impl Grillon {
         self.http_request(Method::GET, path)
     }
 
-    /// Creates a new [`Request`] initialized with a POST method and the given path.
+    /// Creates a new [`Request`] initialized with a `POST` method and the given path.
     ///
     /// # Example
     ///
@@ -66,7 +66,7 @@ impl Grillon {
         self.http_request(Method::POST, path)
     }
 
-    /// Creates a new [`Request`] initialized with a PUT method and the given path.
+    /// Creates a new [`Request`] initialized with a `PUT` method and the given path.
     ///
     /// # Example
     ///
@@ -82,7 +82,7 @@ impl Grillon {
         self.http_request(Method::PUT, path)
     }
 
-    /// Creates a new [`Request`] initialized with a PATCH method and the given path.
+    /// Creates a new [`Request`] initialized with a `PATCH` method and the given path.
     ///
     /// # Example
     ///
@@ -98,7 +98,7 @@ impl Grillon {
         self.http_request(Method::PATCH, path)
     }
 
-    /// Creates a new [`Request`] initialized with a DELETE method and the given path.
+    /// Creates a new [`Request`] initialized with a `DELETE` method and the given path.
     ///
     /// # Example
     ///
@@ -112,6 +112,64 @@ impl Grillon {
     /// ```
     pub fn delete(&self, path: &str) -> Request {
         self.http_request(Method::DELETE, path)
+    }
+
+    /// Creates a new [`Request`] initialized with an `OPTIONS` method and the given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use grillon::{Grillon, Result, header::{ACCESS_CONTROL_ALLOW_METHODS, HeaderValue}};
+    /// # async fn run() -> Result<()> {
+    /// Grillon::new("http://jsonplaceholder.typicode.com")?
+    ///     .options("")
+    ///     .assert()
+    ///     .await
+    ///     .headers_exist(vec![(
+    ///         ACCESS_CONTROL_ALLOW_METHODS,
+    ///         HeaderValue::from_static("GET,HEAD,PUT,PATCH,POST,DELETE"),
+    ///     )]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn options(&self, path: &str) -> Request {
+        self.http_request(Method::OPTIONS, path)
+    }
+
+    /// Creates a new [`Request`] initialized with an `HEAD` method and the given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use grillon::{Grillon, Result, header::{CONTENT_LENGTH, HeaderValue}};
+    /// # async fn run() -> Result<()> {
+    /// Grillon::new("http://jsonplaceholder.typicode.com")?
+    ///     .head("photos/1")
+    ///     .assert()
+    ///     .await
+    ///     .headers_exist(vec![(CONTENT_LENGTH, HeaderValue::from_static("205"))]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn head(&self, path: &str) -> Request {
+        self.http_request(Method::HEAD, path)
+    }
+
+    /// Creates a new [`Request`] initialized with a `CONNECT` method and the given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use grillon::{Grillon, Result};
+    /// # fn run() -> Result<()> {
+    /// let request = Grillon::new("http://home.netscape.com")?
+    ///     .connect("");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn connect(&self, path: &str) -> Request {
+        println!("METHOD = {}", Method::CONNECT.as_str());
+        self.http_request(Method::CONNECT, path)
     }
 
     /// Create a new [`Request`] initialized with the given method and path.

--- a/tests/http/basic_http.rs
+++ b/tests/http/basic_http.rs
@@ -1,6 +1,9 @@
 use crate::HttpMockServer;
 use grillon::{
-    header::{HeaderValue, CONTENT_LOCATION, CONTENT_TYPE},
+    header::{
+        HeaderName, HeaderValue, ACCESS_CONTROL_ALLOW_METHODS, CONTENT_LENGTH, CONTENT_LOCATION,
+        CONTENT_TYPE, USER_AGENT,
+    },
     json, Grillon, Method, Result, StatusCode,
 };
 
@@ -125,6 +128,72 @@ async fn patch_request() -> Result<()> {
         .headers_exist(vec![(
             CONTENT_LOCATION,
             HeaderValue::from_static("/users/1"),
+        )]);
+
+    mock.assert();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn options_request() -> Result<()> {
+    let mock_server = HttpMockServer::new();
+    let mock = mock_server.options();
+
+    Grillon::new(mock_server.server.url("/").as_ref())?
+        .options("")
+        .assert()
+        .await
+        .status_success()
+        .status(StatusCode::NO_CONTENT)
+        .headers_exist(vec![(
+            ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static("OPTIONS, GET, HEAD, POST, PUT, DELETE, PATCH"),
+        )]);
+
+    mock.assert();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn head_request() -> Result<()> {
+    let mock_server = HttpMockServer::new();
+    let mock = mock_server.head();
+
+    Grillon::new(mock_server.server.url("/").as_ref())?
+        .head("movies/1")
+        .assert()
+        .await
+        .status_success()
+        .status(StatusCode::NO_CONTENT)
+        .headers_exist(vec![(CONTENT_LENGTH, HeaderValue::from_static("91750400"))]);
+
+    mock.assert();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn connect_request() -> Result<()> {
+    let mock_server = HttpMockServer::new();
+    let mock = mock_server.connect();
+
+    Grillon::new(mock_server.server.url("/").as_ref())?
+        .connect("")
+        .headers(vec![(
+            USER_AGENT,
+            HeaderValue::from_static(
+                "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+            ),
+        )])
+        .assert()
+        .await
+        .status_success()
+        .status(StatusCode::OK)
+        .headers_exist(vec![(
+            HeaderName::from_static("proxy-agent"),
+            HeaderValue::from_static("Netscape-Proxy/1.1"),
         )]);
 
     mock.assert();

--- a/tests/http_mock_server.rs
+++ b/tests/http_mock_server.rs
@@ -1,5 +1,8 @@
 use httpmock::prelude::*;
-use httpmock::{Method::PATCH, Mock, MockServer};
+use httpmock::{
+    Method::{CONNECT, HEAD, PATCH},
+    Mock, MockServer,
+};
 use serde_json::json;
 
 pub struct HttpMockServer {
@@ -70,6 +73,33 @@ impl HttpMockServer {
                     ]
                 ));
             then.status(204).header("content-location", "/users/1");
+        })
+    }
+
+    pub fn options(&self) -> Mock {
+        self.server.mock(|when, then| {
+            when.method(OPTIONS).path("/");
+            then.status(204).header(
+                "access-control-allow-methods",
+                "OPTIONS, GET, HEAD, POST, PUT, DELETE, PATCH",
+            );
+        })
+    }
+
+    pub fn head(&self) -> Mock {
+        self.server.mock(|when, then| {
+            when.method(HEAD).path("/movies/1");
+            then.status(204).header("content-length", "91750400");
+        })
+    }
+
+    pub fn connect(&self) -> Mock {
+        self.server.mock(|when, then| {
+            when.method(CONNECT).header(
+                "user-agent",
+                "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+            );
+            then.status(200).header("proxy-agent", "Netscape-Proxy/1.1");
         })
     }
 


### PR DESCRIPTION
Extend the built-in functions for sending HEAD, OPTIONS, and
CONNECT http requests.

Closes #8