### PR TITLE
Add a custom assertion function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# `grillon` changelog
+
+## [0.2.0] - 2022-01-22
+
+[0.2.0]: /../../tree/v0.2.0
+
+- [Diff](/../../compare/v0.1.0...v0.2.2)
+- [Milestone](/../../milestone/1)
+
+### Added
+
+- Built-in HTTP functions : `HEAD`, `OPTIONS` and `CONNECT`. ([#8], [#12])
+- `Assert::assert_fn` to extend built-in assertions with a custom assertion. ([#7], [#13], [#14] [#15])
+
+### Changed
+
+- `Assert` fields (`json`, `headers`, `status`) are now public to allow external access. ([#15])
+
+[#7]: /../../issues/7
+[#8]: /../../issues/8
+[#13]: /../../issues/13
+[#12]: /../../pull/12
+[#14]: /../../pull/14
+[#15]: /../../pull/15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grillon"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["theredfish <did.julian@gmail.com>"]
 description = "Grillon offers an elegant and natural way to approach end-to-end HTTP API testing in Rust."
 repository = "https://github.com/theredfish/grillon"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Grillon
 
 [![Crates.io](https://img.shields.io/crates/v/grillon)](https://crates.io/crates/grillon)
-[![docs.rs](https://img.shields.io/docsrs/grillon)](https://docs.rs/grillon/0.1.0/grillon/)
+[![docs.rs](https://img.shields.io/docsrs/grillon)](https://docs.rs/grillon/latest/grillon)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/theredfish/grillon/Rust%20CI)](https://github.com/theredfish/grillon/actions?query=workflow%3A%22Rust+CI%22+branch%3Amain)
 
 Grillon offers an elegant and natural way to approach end-to-end HTTP API testing in Rust.
@@ -12,6 +12,9 @@ Grillon offers an elegant and natural way to approach end-to-end HTTP API testin
 
 > Please note that the API is subject to a lot of changes until the `v1.0.0`.
 
+- [API doc](https://docs.rs/grillon/latest/grillon)
+- [Changelog](https://github.com/theredfish/grillon/blob/main/CHANGELOG.md)
+
 # Getting started
 
 This example enables the optional `diff` feature and uses [Tokio](https://tokio.rs/) as asynchronous runtime.
@@ -21,7 +24,7 @@ Add `grillon` to `Cargo.toml`
 
 ```toml
 [dev-dependencies]
-grillon = { version = "0.1.0", features = ["diff"] }
+grillon = { version = "0.2.0", features = ["diff"] }
 tokio = { version = "1", features = ["macros"] }
 ```
 
@@ -45,6 +48,13 @@ async fn end_to_end_test() -> Result<()> {
         .assert()
         .await
         .status_success()
+        .assert_fn(|assert| {
+            assert!(!assert.headers.is_empty());
+            assert!(assert.status == StatusCode::CREATED);
+            assert!(assert.json.is_some());
+
+            println!("Json response : {:#?}", assert.json);
+        })
         .status(StatusCode::CREATED)
         .headers_exist(vec![(
             CONTENT_TYPE,

--- a/src/assert/mod.rs
+++ b/src/assert/mod.rs
@@ -60,9 +60,9 @@ use serde_json::Value;
 /// The `Assert` uses an internal representation of the
 /// http response to assert it.
 pub struct Assert {
-    headers: HeaderMap,
-    status: StatusCode,
-    json: Option<Value>,
+    pub headers: HeaderMap,
+    pub status: StatusCode,
+    pub json: Option<Value>,
 }
 
 impl Assert {
@@ -81,6 +81,40 @@ impl Assert {
             status,
             json,
         }
+    }
+
+    /// Extends the built-in assertions with a custom assertion.
+    /// The closure gives access to the [`Assert`] instance.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use grillon::{Grillon, Result, StatusCode};
+    /// # async fn custom_assert() -> Result<()> {
+    /// Grillon::new("http://jsonplaceholder.typicode.com")?
+    ///     .get("/users")
+    ///     .assert()
+    ///     .await
+    ///     .status_success()
+    ///     .assert_fn(|assert| {
+    ///         assert!(!assert.headers.is_empty());
+    ///         assert!(assert.status == StatusCode::CREATED);
+    ///         assert!(assert.json.is_some());
+    ///
+    ///         println!("Json response : {:#?}", assert.json);
+    ///      })
+    ///      .status(StatusCode::CREATED);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn assert_fn<F>(self, func: F) -> Assert
+    where
+        F: for<'a> Fn(&'a Assert),
+    {
+        func(&self);
+
+        self
     }
 
     /// Asserts that the response status is equals to the given one.

--- a/tests/assert/assert_fn.rs
+++ b/tests/assert/assert_fn.rs
@@ -1,0 +1,26 @@
+use crate::HttpMockServer;
+use grillon::{Grillon, Result, StatusCode};
+
+#[tokio::test]
+async fn custom_assert() -> Result<()> {
+    let mock_server = HttpMockServer::new();
+    let mock = mock_server.get_valid_user();
+
+    Grillon::new(mock_server.server.url("/").as_ref())?
+        .get("users/1")
+        .assert()
+        .await
+        .status_success()
+        .assert_fn(|assert| {
+            assert!(!assert.headers.is_empty());
+            assert!(assert.status == StatusCode::OK);
+            assert!(assert.json.is_some());
+
+            println!("Json response : {:#?}", assert.json);
+        })
+        .status(StatusCode::OK);
+
+    mock.assert();
+
+    Ok(())
+}

--- a/tests/assert/mod.rs
+++ b/tests/assert/mod.rs
@@ -1,4 +1,5 @@
 mod assert_body;
 mod assert_builder;
+mod assert_fn;
 mod assert_headers;
 mod assert_status;


### PR DESCRIPTION
The built-in assertion functions can now be extended with one or
multiple custom assertions by using `assert_fn`.

Closes #7 #13