### PR TITLE
Update Response::json return type with a lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # `grillon` changelog
 
+## [0.3.0] - 2022-01-25
+
+[0.3.0]: /../../tree/v0.3.0
+
+- [Diff](/../../compare/v0.2.0...v0.3.0)
+
+### Changed
+
+- `Response::json` has now a return type following the standard for `async` functions bounded by the
+  lifetime of their arguments. Now the function should also be compatible with `async_trait` without `Send` requirement.
+  ([#16])
+
+[#16]: /../../pull/16
+
 ## [0.2.0] - 2022-01-22
 
 [0.2.0]: /../../tree/v0.2.0
 
-- [Diff](/../../compare/v0.1.0...v0.2.2)
+- [Diff](/../../compare/v0.1.0...v0.2.0)
 - [Milestone](/../../milestone/1)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grillon"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["theredfish <did.julian@gmail.com>"]
 description = "Grillon offers an elegant and natural way to approach end-to-end HTTP API testing in Rust."
 repository = "https://github.com/theredfish/grillon"
@@ -28,6 +28,7 @@ pretty_assertions = { version = "1.0.0", optional = true }
 tokio = { version = "1.12", features = ["macros"] }
 reqwest = { version = "0.11.4", features = ["json"] }
 httpmock = "0.6.5"
+async-trait = "0.1.52"
 
 [features]
 diff = ["pretty_assertions"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add `grillon` to `Cargo.toml`
 
 ```toml
 [dev-dependencies]
-grillon = { version = "0.2.0", features = ["diff"] }
+grillon = { version = "0.3.0", features = ["diff"] }
 tokio = { version = "1", features = ["macros"] }
 ```
 

--- a/src/assert/mod.rs
+++ b/src/assert/mod.rs
@@ -9,22 +9,22 @@
 //! ```rust
 //! #[tokio::test]
 //! async fn custom_response_struct() -> Result<(), grillon::Error> {
-//!     use futures::FutureExt;
+//!     use async_trait::async_trait;
 //!     use grillon::{header::HeaderMap, Assert, Response, StatusCode};
 //!     use serde_json::Value;
-//!     use std::{future::Future, pin::Pin};
 //!
 //!     struct ResponseWrapper {
 //!         pub response: reqwest::Response,
 //!     }
 //!
+//!     #[async_trait(?Send)]
 //!     impl Response for ResponseWrapper {
 //!         fn status(&self) -> StatusCode {
 //!             self.response.status()
 //!         }
 //!
-//!         fn json(self) -> Pin<Box<dyn Future<Output = Option<Value>>>> {
-//!             async { self.response.json::<Value>().await.ok() }.boxed_local()
+//!         async fn json(self) -> Option<Value> {
+//!             self.response.json::<Value>().await.ok()
 //!         }
 //!
 //!         fn headers(&self) -> HeaderMap {

--- a/src/response.rs
+++ b/src/response.rs
@@ -5,14 +5,13 @@
 //!
 //! [`Assert`]: crate::Assert
 //! [`Grillon`]: crate::Grillon
-use futures::FutureExt;
+use futures::{future::LocalBoxFuture, FutureExt};
 use hyper::{
     body::{Body, Buf},
     header::HeaderMap,
     http::{response::Response as HyperResponse, StatusCode},
 };
 use serde_json::Value;
-use std::{future::Future, pin::Pin};
 
 /// A generic http response representation with
 /// convenience methods for subsequent assertions
@@ -23,7 +22,7 @@ pub trait Response {
     /// Returns the http status code.
     fn status(&self) -> StatusCode;
     /// Returns a future with the response json body.
-    fn json(self) -> Pin<Box<dyn Future<Output = Option<Value>>>>;
+    fn json<'a>(self) -> LocalBoxFuture<'a, Option<Value>>;
     /// Returns the response headers.
     fn headers(&self) -> HeaderMap;
 }
@@ -33,7 +32,7 @@ impl Response for HyperResponse<Body> {
         self.status()
     }
 
-    fn json(self) -> Pin<Box<dyn Future<Output = Option<Value>>>> {
+    fn json<'a>(self) -> LocalBoxFuture<'a, Option<Value>> {
         let (_, body) = self.into_parts();
         let body = hyper::body::aggregate(body);
 


### PR DESCRIPTION
`Response::json` will now be compatible with the async_trait and
the standard async functions that are bounded by the lifetime of
their arguments.