### PR TITLE
Add dynamic dispatch for assertion type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14.7", features = ["client", "http1", "http2", "runtime"] }
-serde = "1.0.137"
+serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 http = "0.2.7"
 url = "2.2.2"
@@ -31,6 +31,7 @@ tokio = { version = "1.18.2", features = ["macros"] }
 reqwest = { version = "0.11.10", features = ["json"] }
 httpmock = "0.6.6"
 async-trait = "0.1.53"
+test-case = "2.2.1"
 
 [features]
 diff = ["pretty_assertions"]

--- a/src/assert/assertion.rs
+++ b/src/assert/assertion.rs
@@ -1,0 +1,122 @@
+use crate::dsl::{part::*, Predicate};
+#[cfg(feature = "diff")]
+use pretty_assertions::assert_eq;
+use std::fmt::Debug;
+
+/// Defines assertion behaviors to implement for a concrete type of assertion.
+pub trait AssertType {
+    /// Runs the assertion with a [`Predicate`] and a [`Part`].
+    fn assert(&self, predicate: &Predicate, part: &Part);
+    /// Builds the assertion message with a [`Predicate`] and a [`Part`].
+    fn message(&self, predicate: &Predicate, part: &Part) -> String;
+}
+
+/// Represents an assertion to test the equality between `left` and `right`. If
+/// the `diff` feature is enabled, the underlying macro `assert_eq!` will
+/// generate a diff for assertion failures.
+pub struct AssertEq<T> {
+    /// The left-hand operand under strict equality test.
+    pub left: T,
+    /// The right-hand operand under strict equality test.
+    pub right: T,
+}
+
+impl<T> AssertType for AssertEq<T>
+where
+    T: PartialEq + Debug,
+{
+    fn assert(&self, predicate: &Predicate, part: &Part) {
+        assert_eq!(self.left, self.right, "{}", self.message(predicate, part))
+    }
+
+    fn message(&self, predicate: &Predicate, part: &Part) -> String {
+        format!(
+            "{} {} {:#?}. Found {:#?}.",
+            part, predicate, self.right, self.left
+        )
+    }
+}
+
+/// Represents an assertion to test the non-equality between `left` and `right`.
+pub struct AssertNe<T> {
+    /// The left-hand operand under strict non-equality test.
+    pub left: T,
+    /// The right-hand operand under strict non-equality test.
+    pub right: T,
+}
+
+impl<T> AssertType for AssertNe<T>
+where
+    T: PartialEq + Debug,
+{
+    fn assert(&self, predicate: &Predicate, part: &Part) {
+        assert_ne!(self.left, self.right, "{}", self.message(predicate, part))
+    }
+
+    fn message(&self, predicate: &Predicate, part: &Part) -> String {
+        format!(
+            "{} {} {:#?}. Found {:#?}.",
+            part, predicate, self.right, self.left
+        )
+    }
+}
+
+/// Represents an assertion between `left` and `right` with a test expression.
+pub struct AssertBool<T, U> {
+    /// The left-hand operand under test.
+    pub left: T,
+    /// The right-hand operand under test.
+    pub right: U,
+    /// The test expression result.
+    pub result: bool,
+}
+
+impl<T, U> AssertType for AssertBool<T, U>
+where
+    T: PartialEq + Debug,
+    U: PartialEq + Debug,
+{
+    fn assert(&self, predicate: &Predicate, part: &Part) {
+        assert!(self.result, "{}", self.message(predicate, part))
+    }
+
+    fn message(&self, predicate: &Predicate, part: &Part) -> String {
+        format!(
+            "{} {} {:#?}. Found {:#?}.",
+            part, predicate, self.right, self.left
+        )
+    }
+}
+
+/// Represents an assertion event that we can emit.
+///
+/// An [`Assertion`] is composed of a type [`AssertType`] to determine
+/// what kind of assertion to run, of a [`Predicate`] for the condition
+/// of the assertion and a [`Part`] under test.
+pub struct Assertion {
+    ty: Box<dyn AssertType>,
+    predicate: Predicate,
+    part: Part,
+}
+
+impl Assertion {
+    /// Creates a new [`Assertion`].
+    pub fn new(ty: Box<dyn AssertType>, predicate: Predicate, part: Part) -> Self {
+        Self {
+            ty,
+            predicate,
+            part,
+        }
+    }
+
+    /// Emits an assertion by evaluating the correct assertion macro to match.
+    ///
+    /// This function constructs an assertion message based on the [`Predicate`],
+    /// the [`Part`] under test and the [`AssertType`], which will be used in
+    /// case the assertion fails.
+    ///
+    /// [`emit_multi_types()`]: [`Self::emit_multi_types()`]
+    pub fn emit(&self) {
+        self.ty.assert(&self.predicate, &self.part)
+    }
+}

--- a/src/dsl/http/body.rs
+++ b/src/dsl/http/body.rs
@@ -1,21 +1,20 @@
-use crate::assert::{
-    Assertion,
-    AssertionType::{Equals, NotEquals},
-};
-use crate::dsl::{
-    expression::Predicate::{self, Is, IsNot},
-    part::Part,
+use crate::{
+    assert::{AssertEq, AssertNe, Assertion},
+    dsl::{
+        expression::Predicate::{self, Is, IsNot},
+        part::Part,
+    },
 };
 use serde_json::Value;
 
 /// Http json body DSL to assert body of a response.
 pub trait JsonBodyDsl<T> {
     /// Asserts the json response body is strictly equals to the provided value.
-    fn is(&self, actual: &T);
+    fn is(&self, actual: T) -> Assertion;
     /// Asserts the json response body is strictly not equals to the provided value.
-    fn is_not(&self, actual: &T);
+    fn is_not(&self, actual: T) -> Assertion;
     /// Evaluates the json body assertion to run based on the [`Predicate`].
-    fn eval(&self, actual: &T, predicate: Predicate) {
+    fn eval(&self, actual: T, predicate: Predicate) -> Assertion {
         match predicate {
             Is => self.is(actual),
             IsNot => self.is_not(actual),
@@ -25,35 +24,65 @@ pub trait JsonBodyDsl<T> {
 }
 
 impl JsonBodyDsl<Value> for Value {
-    fn is(&self, actual: &Value) {
-        Assertion::emit(actual, self, Equals, Is, Part::JsonBody)
+    fn is(&self, actual: Value) -> Assertion {
+        let ty = AssertEq {
+            left: actual,
+            right: self.clone(),
+        };
+
+        Assertion::new(Box::new(ty), Is, Part::JsonBody)
     }
 
-    fn is_not(&self, actual: &Value) {
-        Assertion::emit(actual, self, NotEquals, IsNot, Part::JsonBody)
+    fn is_not(&self, actual: Value) -> Assertion {
+        let ty = AssertNe {
+            left: actual,
+            right: self.clone(),
+        };
+
+        Assertion::new(Box::new(ty), IsNot, Part::JsonBody)
     }
 }
 
 impl JsonBodyDsl<Value> for &str {
-    fn is(&self, actual: &Value) {
+    fn is(&self, actual: Value) -> Assertion {
         let expected: Value = serde_json::from_str(self).ok().unwrap();
-        Assertion::emit(actual, &expected, Equals, Is, Part::JsonBody)
+        let ty = AssertEq {
+            left: actual,
+            right: expected,
+        };
+
+        Assertion::new(Box::new(ty), Is, Part::JsonBody)
     }
 
-    fn is_not(&self, actual: &Value) {
+    fn is_not(&self, actual: Value) -> Assertion {
         let expected: Value = serde_json::from_str(self).ok().unwrap();
-        Assertion::emit(actual, &expected, NotEquals, IsNot, Part::JsonBody)
+        let ty = AssertNe {
+            left: actual,
+            right: expected,
+        };
+
+        Assertion::new(Box::new(ty), IsNot, Part::JsonBody)
     }
 }
 
 impl JsonBodyDsl<Value> for String {
-    fn is(&self, actual: &Value) {
+    fn is(&self, actual: Value) -> Assertion {
         let expected: Value = serde_json::from_str(self).ok().unwrap();
-        Assertion::emit(actual, &expected, Equals, Is, Part::JsonBody)
+        let ty = AssertEq {
+            left: actual,
+            right: expected,
+        };
+
+        Assertion::new(Box::new(ty), Is, Part::JsonBody)
     }
 
-    fn is_not(&self, actual: &Value) {
+    fn is_not(&self, actual: Value) -> Assertion {
         let expected: Value = serde_json::from_str(self).ok().unwrap();
-        Assertion::emit(actual, &expected, NotEquals, IsNot, Part::JsonBody)
+        let ty = AssertNe {
+            left: actual,
+            right: expected,
+        };
+
+        Assertion::new(Box::new(ty), IsNot, Part::JsonBody)
     }
 }

--- a/src/dsl/http/time.rs
+++ b/src/dsl/http/time.rs
@@ -1,5 +1,5 @@
 use crate::{
-    assert::{Assertion, AssertionType::Test},
+    assert::{AssertBool, Assertion},
     dsl::{
         expression::Predicate::{self, LessThan},
         part::Part,
@@ -10,9 +10,9 @@ use crate::{
 pub trait TimeDsl<T> {
     /// Asserts the response time is strictly inferior to the provided time in
     /// milliseconds.
-    fn is_less_than(&self, actual: &T);
+    fn is_less_than(&self, actual: T) -> Assertion;
     /// Evaluates the time assertion to run based on the [`Predicate`]
-    fn eval(&self, actual: &T, operator: Predicate) {
+    fn eval(&self, actual: T, operator: Predicate) -> Assertion {
         match operator {
             Predicate::LessThan => self.is_less_than(actual),
             _ => unimplemented!(),
@@ -21,9 +21,17 @@ pub trait TimeDsl<T> {
 }
 
 impl TimeDsl<u128> for u128 {
-    fn is_less_than(&self, actual: &u128) {
-        let result = actual < self;
+    fn is_less_than(&self, actual: u128) -> Assertion {
+        let result = actual < *self;
 
-        Assertion::emit(actual, self, Test(result), LessThan, Part::ResponseTime)
+        // Assertion::emit(actual, self, Test(result), LessThan, Part::ResponseTime);
+
+        let ty = AssertBool {
+            left: actual,
+            right: *self,
+            result,
+        };
+
+        Assertion::new(Box::new(ty), LessThan, Part::ResponseTime)
     }
 }

--- a/src/dsl/part.rs
+++ b/src/dsl/part.rs
@@ -1,26 +1,48 @@
 //! Module containing all the different parts we can assert against. These parts
 //! are also used to build assertion messages in a convenient way.
 
+use serde::Deserialize;
 use strum::Display;
 
 /// Represents all the parts we can assert against. Provides a string
 /// representation for each variant to build assertion messages in a convenient
 /// way.
-#[derive(Display)]
+#[derive(Display, Deserialize, PartialEq, Eq, Debug)]
 pub enum Part {
     /// The json body of an http response.
     #[strum(serialize = "json body")]
+    #[serde(rename = "json body")]
     JsonBody,
     /// The headers in an http response.
     #[strum(serialize = "headers")]
+    #[serde(rename = "headers")]
     Headers,
     /// A header in an http response.
     #[strum(serialize = "header")]
+    #[serde(rename = "header")]
     Header,
     /// The status code of an http response.
     #[strum(serialize = "status code")]
+    #[serde(rename = "status code")]
     StatusCode,
     /// The response time of an http response.
     #[strum(serialize = "response time")]
+    #[serde(rename = "response time")]
     ResponseTime,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::Part;
+    use serde_json::Value;
+    use test_case::test_case;
+
+    #[test_case(Value::String(String::from("json body")), Part::JsonBody; "Failed to deserialize part JsonBody")]
+    #[test_case(Value::String(String::from("headers")), Part::Headers; "Failed to deserialize part Headers")]
+    #[test_case(Value::String(String::from("header")), Part::Header; "Failed to deserialize part Header")]
+    #[test_case(Value::String(String::from("status code")), Part::StatusCode; "Failed to deserialize part StatusCode")]
+    #[test_case(Value::String(String::from("response time")), Part::ResponseTime; "Failed to deserialize part ResponseTime")]
+    fn deser_part(json_part: Value, part: Part) {
+        assert_eq!(serde_json::from_value::<Part>(json_part).unwrap(), part)
+    }
 }


### PR DESCRIPTION
Improve the api to better encapsulate assertion information
and avoid different emit functions to cover complex types.
Remove `emit_multi_types` and keep one generic `emit` function
that is implemented on different assertion types : `AssertEq`,
`AssertNe` and `AssertBool`.

This commit also improve the separation of concerns for the DSL.
Now it returns an `Assertion` instead of emitting events.