### PR TITLE
Add optional cookie store to the http client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ futures = "0.3.30"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 jsonpath-rust = "0.7.0"
-jsonschema = "0.19.1"
-reqwest = { version = "0.12.7", features = ["json"] }
+jsonschema = "0.20.0"
+reqwest = { version = "0.12.7", features = ["json", "cookies"] }
 thiserror = "1.0.63"
 
 [dev-dependencies]

--- a/book/src/writing_tests/client_configuration.md
+++ b/book/src/writing_tests/client_configuration.md
@@ -38,6 +38,29 @@ Refer to the [Requests](./requests.md) chapter for more information about how to
 requests. Note that at the moment Grillon only supports HTTP(s), but later we will extend the use
 for different protocols and frameworks such as gRPC or SSL.
 
+### Store cookies
+
+You can update your client to enable or disable the cookie store with `store_cookies`:
+
+```rust
+// If an http response contains `Set-Cookie` headers, then cookies will be saved for
+// subsequent http requests.
+let grillon = Grillon::new("https://server.com")?.store_cookies(true)?;
+
+grillon.post("auth").assert().await.headers(contains(vec![(
+    SET_COOKIE,
+    HeaderValue::from_static("SESSIONID=123; HttpOnly"),
+)]));
+
+grillon
+    .get("authenticated/endpoint") // An endpoint where the session cookie `SESSIONID=123` is required.
+    .assert()
+    .await
+    .status(is_success());
+```
+
+The cookie store is disabled by default.
+
 ## Use a different client
 
 When you want to use a different client to send your requests and handle the responses, you should

--- a/src/assertion/impls/json_body.rs
+++ b/src/assertion/impls/json_body.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     dsl::{Part, Predicate},
 };
-use jsonschema::{output::BasicOutput, JSONSchema};
+use jsonschema::{output::BasicOutput, Validator};
 use serde_json::Value;
 use std::{fs, path::PathBuf};
 
@@ -199,7 +199,7 @@ impl JsonSchema<Value> for Value {
     type Assertion = Assertion<Value>;
 
     fn matches_schema(&self, schema: &Value) -> Self::Assertion {
-        let schema = match JSONSchema::compile(schema) {
+        let schema = match Validator::new(schema) {
             Ok(schema) => schema,
             Err(err) => {
                 return Assertion {
@@ -640,7 +640,7 @@ mod tests {
         }
 
         #[test]
-        fn impl_schema_compile_error() {
+        fn impl_schema_validation_error() {
             let schema: serde_json::Value = json!({
               "$schema": "http://json-schema.org/draft-04/schema#",
               "title": "Bad json schema",

--- a/src/assertion/impls/json_path.rs
+++ b/src/assertion/impls/json_path.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     dsl::{json_path::JsonPathResult, Part, Predicate},
 };
-use jsonschema::{output::BasicOutput, JSONSchema};
+use jsonschema::{output::BasicOutput, Validator};
 use serde_json::Value;
 use std::{fs, path::PathBuf};
 
@@ -200,7 +200,7 @@ impl JsonSchema<Value> for JsonPathResult<'_, Value> {
     type Assertion = Assertion<Value>;
 
     fn matches_schema(&self, schema: &Value) -> Self::Assertion {
-        let schema = match JSONSchema::compile(schema) {
+        let schema = match Validator::new(schema) {
             Ok(schema) => schema,
             Err(err) => {
                 return Assertion {

--- a/src/assertion/mod.rs
+++ b/src/assertion/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     dsl::{Part, Predicate},
     grillon::LogSettings,
 };
-use jsonschema::paths::JSONPointer;
+use jsonschema::paths::JsonPointer;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::any::Any;
@@ -97,7 +97,7 @@ pub enum UnprocessableReason {
     /// Unprocessable json body because it's missing.
     JsonBodyMissing,
     /// Unprocessable json schema.
-    InvalidJsonSchema(JSONPointer, JSONPointer),
+    InvalidJsonSchema(JsonPointer, JsonPointer),
     /// Serialization failure.
     SerializationFailure(String),
     /// Unprocessable entity.

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,4 +9,7 @@ pub enum Error {
     /// Url parse error.
     #[error("Invalid URL")]
     UrlParseError(#[from] ParseError),
+    /// Http client error.
+    #[error("Http client error")]
+    HttpClientError(#[from] reqwest::Error),
 }

--- a/src/grillon.rs
+++ b/src/grillon.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::Request;
 use http::{HeaderMap, Method};
-use reqwest::Client;
+use reqwest::{Client, ClientBuilder};
 use url::Url;
 
 /// Top-level instance to configure a REST API http client.
@@ -50,9 +50,11 @@ impl Grillon {
     ///
     /// This function fails if the supplied base url cannot be parsed as a [`Url`].
     pub fn new(base_url: &str) -> Result<Grillon> {
+        let client = ClientBuilder::new().cookie_store(false).build()?;
+
         Ok(Grillon {
             base_url: base_url.parse::<Url>()?,
-            client: reqwest::Client::new(),
+            client,
             log_settings: LogSettings::default(),
         })
     }
@@ -65,6 +67,16 @@ impl Grillon {
         self.log_settings = log_settings;
 
         self
+    }
+
+    /// Enable a persistent cookie store for the client. By default,
+    /// no cookie store is used. Enabling the cookie store with `store_cookies()`
+    /// will update the http client and set the store to a default implementation.
+    pub fn store_cookies(mut self, enable: bool) -> Result<Grillon> {
+        let client = ClientBuilder::new().cookie_store(enable).build()?;
+        self.client = client;
+
+        Ok(self)
     }
 
     /// Creates a new [`Request`] initialized with a `GET` method and the given path.

--- a/tests/assert/cookies.rs
+++ b/tests/assert/cookies.rs
@@ -1,0 +1,86 @@
+use crate::HttpMockServer;
+use grillon::dsl::{
+    contains,
+    http::{is_client_error, is_success},
+};
+use grillon::{
+    header::{HeaderValue, SET_COOKIE},
+    Grillon, Result,
+};
+
+#[tokio::test]
+async fn cookies_should_be_stored() -> Result<()> {
+    let mock_server = HttpMockServer::new();
+    let auth_mock = mock_server.auth();
+    let auth_endpoint_mock = mock_server.authenticated_request();
+
+    let grillon = Grillon::new(&mock_server.server.url("/"))?.store_cookies(true)?;
+
+    grillon.post("auth").assert().await.headers(contains(vec![(
+        SET_COOKIE,
+        HeaderValue::from_static("SESSIONID=123; HttpOnly"),
+    )]));
+
+    grillon
+        .get("authenticated/endpoint")
+        .assert()
+        .await
+        .status(is_success());
+
+    auth_mock.assert();
+    auth_endpoint_mock.assert();
+
+    Ok(())
+}
+
+#[tokio::test]
+#[should_panic]
+async fn disabled_cookie_store_should_not_send_cookies() {
+    let mock_server = HttpMockServer::new();
+    let auth_mock = mock_server.auth();
+    let auth_endpoint_mock = mock_server.authenticated_request();
+
+    let grillon = Grillon::new(&mock_server.server.url("/")).unwrap();
+
+    grillon.post("auth").assert().await.headers(contains(vec![(
+        SET_COOKIE,
+        HeaderValue::from_static("SESSIONID=123; HttpOnly"),
+    )]));
+
+    grillon
+        .store_cookies(false)
+        .unwrap()
+        .get("authenticated/endpoint")
+        .assert()
+        .await
+        .status(is_client_error());
+
+    auth_mock.assert();
+    // This should panic because the SESSIONID cookie isn't set.
+    auth_endpoint_mock.assert();
+}
+
+#[tokio::test]
+#[should_panic]
+async fn missing_cookies_should_panic() {
+    let mock_server = HttpMockServer::new();
+    let auth_mock = mock_server.auth();
+    let auth_endpoint_mock = mock_server.authenticated_request();
+
+    let grillon = Grillon::new(&mock_server.server.url("/")).unwrap();
+
+    grillon.post("auth").assert().await.headers(contains(vec![(
+        SET_COOKIE,
+        HeaderValue::from_static("SESSIONID=123; HttpOnly"),
+    )]));
+
+    grillon
+        .get("authenticated/endpoint")
+        .assert()
+        .await
+        .status(is_client_error());
+
+    auth_mock.assert();
+    // This should panic because the SESSIONID cookie isn't set.
+    auth_endpoint_mock.assert();
+}

--- a/tests/assert/mod.rs
+++ b/tests/assert/mod.rs
@@ -1,4 +1,5 @@
 mod assert_fn;
+mod cookies;
 mod headers;
 mod json_body;
 mod json_path;

--- a/tests/http_mock_server.rs
+++ b/tests/http_mock_server.rs
@@ -117,4 +117,21 @@ impl HttpMockServer {
             then.status(500);
         })
     }
+
+    pub fn auth(&self) -> Mock {
+        self.server.mock(|when, then| {
+            when.method(POST).path("/auth");
+            then.status(200)
+                .header("Set-Cookie", "SESSIONID=123; HttpOnly");
+        })
+    }
+
+    pub fn authenticated_request(&self) -> Mock {
+        self.server.mock(|when, then| {
+            when.method(GET)
+                .path("/authenticated/endpoint")
+                .cookie("SESSIONID", "123");
+            then.status(200);
+        })
+    }
 }


### PR DESCRIPTION
By calling `store_cookies` on a Grillon instance, users can enable the cookie store. If an http response contains `Set-Cookie` headers they will be saved by the http client for subsequent requests.

This commit also bump the jsonschema dependency to 0.20.0.

Solves #54